### PR TITLE
Implemented the option to specify the payment intent

### DIFF
--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Abstractions/IPayPalManager.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Abstractions/IPayPalManager.cs
@@ -6,9 +6,9 @@ namespace PayPal.Forms.Abstractions
 {
 	public interface IPayPalManager
 	{
-		Task<PaymentResult> Buy (PayPalItem[] items, Decimal shipping, Decimal tax, ShippingAddress address = null);
+		Task<PaymentResult> Buy (PayPalItem[] items, Decimal shipping, Decimal tax, ShippingAddress address = null, PaymentIntent intent = PaymentIntent.Sale);
 
-		Task<PaymentResult> Buy(PayPalItem item, Decimal tax, ShippingAddress address = null);
+		Task<PaymentResult> Buy(PayPalItem item, Decimal tax, ShippingAddress address = null, PaymentIntent intent = PaymentIntent.Sale);
 
 		Task<FuturePaymentsResult> RequestFuturePayments();
 
@@ -19,4 +19,3 @@ namespace PayPal.Forms.Abstractions
 		string ClientMetadataId { get; }
 	}
 }
-

--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Android/PayPalManager.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Android/PayPalManager.cs
@@ -10,6 +10,7 @@ using Org.Json;
 using Xamarin.PayPal.Android.CardIO.Payment;
 using Android.Graphics;
 using System.Globalization;
+using PayPal.Forms.Abstractions.Enum;
 
 namespace PayPal.Forms
 {
@@ -99,6 +100,7 @@ namespace PayPal.Forms
 			PayPal.Forms.Abstractions.PayPalItem[] items,
 			Decimal xfshipping,
 			Decimal xftax,
+			PaymentIntent xfintent,
 			Action onCancelled,
 			Action<string> onSuccess,
 			Action<string> onError,
@@ -127,7 +129,24 @@ namespace PayPal.Forms
 			PayPalPaymentDetails paymentDetails = new PayPalPaymentDetails (shipping, subtotal, tax);
 			BigDecimal amount = subtotal.Add (shipping).Add (tax);
 
-			PayPalPayment payment = new PayPalPayment (amount, nativeItems.FirstOrDefault().Currency, "Multiple items", PayPalPayment.PaymentIntentSale);
+			string paymentIntent;
+			switch (xfintent)
+			{
+				case PaymentIntent.Authorize:
+					paymentIntent = PayPalPayment.PaymentIntentAuthorize;
+					break;
+
+				case PaymentIntent.Order:
+					paymentIntent = PayPalPayment.PaymentIntentOrder;
+					break;
+
+				default:
+				case PaymentIntent.Sale:
+					paymentIntent = PayPalPayment.PaymentIntentSale;
+					break;
+			}
+
+			PayPalPayment payment = new PayPalPayment (amount, nativeItems.FirstOrDefault().Currency, "Multiple items", paymentIntent);
 			payment = payment.Items (nativeItems.ToArray ()).PaymentDetails (paymentDetails);
 
 			if (address != null)
@@ -166,6 +185,7 @@ namespace PayPal.Forms
 		public void BuyItem(
 			PayPal.Forms.Abstractions.PayPalItem item,
 			Decimal xftax,
+			PaymentIntent xfintent,
 			Action onCancelled,
 			Action<string> onSuccess,
 			Action<string> onError,
@@ -178,7 +198,24 @@ namespace PayPal.Forms
 			OnError = onError;
 			BigDecimal amount = new BigDecimal(RoundNumber((double)item.Price)).Add(new BigDecimal(RoundNumber((double)xftax)));
 
-			PayPalPayment payment = new PayPalPayment(amount, item.Currency, item.Name, PayPalPayment.PaymentIntentSale);
+			string paymentIntent;
+			switch (xfintent)
+			{
+			  case PaymentIntent.Authorize:
+			    paymentIntent = PayPalPayment.PaymentIntentAuthorize;
+			    break;
+
+			  case PaymentIntent.Order:
+			    paymentIntent = PayPalPayment.PaymentIntentOrder;
+			    break;
+
+			  default:
+			  case PaymentIntent.Sale:
+			    paymentIntent = PayPalPayment.PaymentIntentSale;
+			    break;
+			}
+
+			PayPalPayment payment = new PayPalPayment(amount, item.Currency, item.Name, paymentIntent);
 
 			if (address != null)
 			{
@@ -428,4 +465,3 @@ namespace PayPal.Forms
 		}
 	}
 }
-

--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Android/PayPalManagerImplementation.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Android/PayPalManagerImplementation.cs
@@ -21,7 +21,7 @@ namespace PayPal.Forms
 
 		#region IPayPalManager implementation
 
-		public Task<PaymentResult> Buy(PayPalItem[] items, Decimal shipping, Decimal tax, ShippingAddress address = null)
+		public Task<PaymentResult> Buy(PayPalItem[] items, Decimal shipping, Decimal tax, ShippingAddress address = null, PaymentIntent intent = PaymentIntent.Sale)
 		{
 			if (buyTcs != null)
 			{
@@ -29,11 +29,11 @@ namespace PayPal.Forms
 				buyTcs.TrySetResult(null);
 			}
 			buyTcs = new TaskCompletionSource<PaymentResult>();
-			Manager.BuyItems(items, shipping, tax, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
+			Manager.BuyItems(items, shipping, tax, intent, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
 			return buyTcs.Task;
 		}
 
-		public Task<PaymentResult> Buy(PayPalItem item, Decimal tax, ShippingAddress address = null)
+		public Task<PaymentResult> Buy(PayPalItem item, Decimal tax, ShippingAddress address = null, PaymentIntent intent = PaymentIntent.Sale)
 		{
 			if (buyTcs != null)
 			{
@@ -41,7 +41,7 @@ namespace PayPal.Forms
 				buyTcs.TrySetResult(null);
 			}
 			buyTcs = new TaskCompletionSource<PaymentResult>();
-			Manager.BuyItem(item, tax, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
+			Manager.BuyItem(item, tax, intent, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
 			return buyTcs.Task;
 		}
 
@@ -185,4 +185,3 @@ namespace PayPal.Forms
 		}
 	}
 }
-

--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.iOS/PayPalManager.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.iOS/PayPalManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UIKit;
 using System.Linq;
 using System.Globalization;
+using PayPal.Forms.Abstractions.Enum;
 
 namespace PayPal.Forms
 {
@@ -200,6 +201,7 @@ namespace PayPal.Forms
             PayPal.Forms.Abstractions.PayPalItem[] items,
             Decimal xfshipping,
             Decimal xftax,
+            PaymentIntent xfintent,
             Action onCancelled,
             Action<string> onSuccess,
             Action<string> onError,
@@ -231,7 +233,24 @@ namespace PayPal.Forms
 
             var total = subtotal.Add(shipping).Add(tax);
 
-            var payment = PayPalPayment.PaymentWithAmount(total, nativeItems.FirstOrDefault().Currency, "Multiple items", PayPalPaymentIntent.Sale);
+            PayPalPaymentIntent paymentIntent;
+            switch (xfintent)
+            {
+                case PaymentIntent.Authorize:
+                    paymentIntent = PayPalPaymentIntent.Authorize;
+                    break;
+
+                case PaymentIntent.Order:
+                    paymentIntent = PayPalPaymentIntent.Order;
+                    break;
+
+                default:
+                case PaymentIntent.Sale:
+                    paymentIntent = PayPalPaymentIntent.Sale;
+                    break;
+            }
+
+            var payment = PayPalPayment.PaymentWithAmount(total, nativeItems.FirstOrDefault().Currency, "Multiple items", paymentIntent);
             payment.Items = nativeItems.ToArray();
             payment.PaymentDetails = paymentDetails;
 
@@ -278,6 +297,7 @@ namespace PayPal.Forms
         public void BuyItem(
             PayPal.Forms.Abstractions.PayPalItem item,
             Decimal xftax,
+            PaymentIntent xfintent,
             Action onCancelled,
             Action<string> onSuccess,
             Action<string> onError,
@@ -295,7 +315,24 @@ namespace PayPal.Forms
 
             var paymentDetails = PayPalPaymentDetails.PaymentDetailsWithSubtotal(subTotal, new NSDecimalNumber(0), new NSDecimalNumber(RoundNumber((double)xftax)));
 
-            var payment = PayPalPayment.PaymentWithAmount(amount, item.Currency, item.Name, PayPalPaymentIntent.Sale);
+            PayPalPaymentIntent paymentIntent;
+            switch (xfintent)
+            {
+                case PaymentIntent.Authorize:
+                    paymentIntent = PayPalPaymentIntent.Authorize;
+                break;
+
+                case PaymentIntent.Order:
+                    paymentIntent = PayPalPaymentIntent.Order;
+                break;
+
+                default:
+                case PaymentIntent.Sale:
+                    paymentIntent = PayPalPaymentIntent.Sale;
+                break;
+            }
+
+            var payment = PayPalPayment.PaymentWithAmount(amount, item.Currency, item.Name, paymentIntent);
             payment.PaymentDetails = paymentDetails;
             payment.Items = new NSObject[]{
                 PayPalItem.ItemWithName (

--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.iOS/PayPalManagerImplementation.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.iOS/PayPalManagerImplementation.cs
@@ -18,25 +18,25 @@ namespace PayPal.Forms
 
 		#region IPayPalManager implementation
 
-		public Task<PaymentResult> Buy (PayPalItem[] items, Decimal shipping, Decimal tax, ShippingAddress address = null)
+		public Task<PaymentResult> Buy (PayPalItem[] items, Decimal shipping, Decimal tax, ShippingAddress address = null, PaymentIntent intent = PaymentIntent.Sale)
 		{
 			if (buyTcs != null) {
 				buyTcs.TrySetCanceled ();
 				buyTcs.TrySetResult (null);
 			}
 			buyTcs = new TaskCompletionSource<PaymentResult> ();
-			Manager.BuyItems (items, shipping, tax, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
+			Manager.BuyItems (items, shipping, tax, intent, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
 			return buyTcs.Task;
 		}
 
-		public Task<PaymentResult> Buy (PayPalItem item, Decimal tax, ShippingAddress address = null)
+		public Task<PaymentResult> Buy (PayPalItem item, Decimal tax, ShippingAddress address = null, PaymentIntent intent = PaymentIntent.Sale)
 		{
 			if (buyTcs != null) {
 				buyTcs.TrySetCanceled ();
 				buyTcs.TrySetResult (null);
 			}
 			buyTcs = new TaskCompletionSource<PaymentResult> ();
-			Manager.BuyItem (item, tax, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
+			Manager.BuyItem (item, tax, intent, SendOnPayPalPaymentDidCancel, SendOnPayPalPaymentCompleted, SendOnPayPalPaymentError, address);
 			return buyTcs.Task;
 		}
 
@@ -162,4 +162,3 @@ namespace PayPal.Forms
 		}
 	}
 }
-


### PR DESCRIPTION
Hi,

as the native PayPal SDKs support `PaymentIntents` already this change does only add an public API to do so with PayPal.Forms.

The default behavior while not specifying an `PaymentIntent` remains `PaymentIntent.Sale`. This means, that this merge request does not introduce a breaking change.

So a typical call with a custom `PaymentIntent` will look like this:

```csharp
using PayPal.Forms;
using PayPal.Forms.Abstractions;
using PayPal.Forms.Abstractions.Enum;

...

var item = new PayPalItem("My cart item", 5M, "USD");
var result = await CrossPayPalManager.Current.Buy(item, 0M, intent: PaymentIntent.Authorize);

...
```

best regards