### PR TITLE
Scanning configurations

### DIFF
--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Abstractions/PayPalConfiguration.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Abstractions/PayPalConfiguration.cs
@@ -24,6 +24,12 @@ namespace PayPal.Forms.Abstractions
 
         public ShippingAddressOption ShippingAddressOption { get; set; }
 
+        public bool ScanRequiresExpiry { get; set; } = true;
+
+        public bool ScanRequiresCvv { get; set; } = true;
+
+        public bool ScanExpiry { get; set; } = true;
+
         public PayPalConfiguration(PayPalEnvironment environment, string idEnvironment)
         {
             this.Environment = environment;

--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Android/PayPalManager.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.Android/PayPalManager.cs
@@ -184,6 +184,10 @@ namespace PayPal.Forms
             _retrieveCardCancelled = onCancelled;
             _retrieveCardSuccess = onSuccess;
 
+            var requireExpiry = _formsConfig == null || _formsConfig.ScanRequiresExpiry;
+            var requireCvv = _formsConfig == null || _formsConfig.ScanRequiresCvv;
+            var scanExpiry = _formsConfig == null || _formsConfig.ScanExpiry;
+
             Intent intent = new Intent(Context, typeof(CardIOActivity));
             switch (scannerLogo)
             {
@@ -197,8 +201,9 @@ namespace PayPal.Forms
                     break;
             }
             intent.PutExtra(CardIOActivity.ExtraReturnCardImage, true);
-            intent.PutExtra(CardIOActivity.ExtraRequireExpiry, true);
-            intent.PutExtra(CardIOActivity.ExtraRequireCvv, true);
+            intent.PutExtra(CardIOActivity.ExtraRequireExpiry, requireExpiry);
+            intent.PutExtra(CardIOActivity.ExtraRequireCvv, requireCvv);
+            intent.PutExtra(CardIOActivity.ExtraScanExpiry, scanExpiry);
             (Context as Activity).StartActivityForResult(intent, REQUEST_CODE_CARD_SCAN);
         }
 

--- a/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.iOS/PayPalManager.cs
+++ b/MobileApps/PayPal.Forms/PayPal.Forms/PayPal.Forms.iOS/PayPalManager.cs
@@ -340,6 +340,11 @@ namespace PayPal.Forms
         {
             _retrieveCardCancelled = onCancelled;
             _retrieveCardSuccess = onSuccess;
+
+            var requireExpiry = _formsConfig == null || _formsConfig.ScanRequiresExpiry;
+            var requireCvv = _formsConfig == null || _formsConfig.ScanRequiresCvv;
+            var scanExpiry = _formsConfig == null || _formsConfig.ScanExpiry;
+
             var scanViewController = new CardIOPaymentViewController(new CustomCardIOPaymentViewControllerDelegate(this));
 
             switch (scannerLogo)
@@ -353,6 +358,11 @@ namespace PayPal.Forms
                     scanViewController.UseCardIOLogo = false;
                     break;
             }
+
+            scanViewController.CollectExpiry = requireExpiry;
+            scanViewController.CollectCVV = requireCvv;
+            scanViewController.ScanExpiry = scanExpiry;
+
             var top = GetTopViewController(UIApplication.SharedApplication.KeyWindow);
             top.PresentViewController(scanViewController, true, null);
         }


### PR DESCRIPTION
Needed the ability disable the CVV and expiry input prompt after scanning a credit card.

This PR adds the ability to set CVV and expiry collection/requirement via `PayPalConfiguration` for card scanning.  Platform-specific `PayPalManager` implementations will read the configuration values and set the UI accordingly.  Everything defaults to `true` to maintain existing functionality.